### PR TITLE
Tsa76 fosscuda 2019b

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-fosscuda-2019b-python2.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-fosscuda-2019b-python2.eb
@@ -1,0 +1,23 @@
+# contributed by Luca Marsella
+name = 'Boost'
+version = '1.70.0'
+versionsuffix = '-python2'
+
+homepage = 'http://www.boost.org/'
+description = "Boost provides free peer-reviewed portable C++ source libraries."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(namelower)s_1_70_0.tar.gz']
+
+builddependencies = [
+    ('zlib', '1.2.11'),
+    ('Python', '2.7.16', '', True),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-fosscuda-2019b-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-fosscuda-2019b-python3.eb
@@ -1,0 +1,24 @@
+# contributed by Luca Marsella
+name = 'Boost'
+version = '1.70.0'
+versionsuffix = '-python3'
+
+homepage = 'http://www.boost.org/'
+description = "Boost provides free peer-reviewed portable C++ source libraries."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(namelower)s_1_70_0.tar.gz']
+patches = ['%(name)s-%(version)s-python3.patch']
+
+builddependencies = [
+    ('zlib', '1.2.11'),
+    ('Python', '3.7.4', '', True),
+]
+
+# also build boost_mpi
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.7.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.7.1-fosscuda-2019b.eb
@@ -1,0 +1,38 @@
+# Updated by @gppezzi @jgphpc and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.9.7.1'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = "CDO is a collection of command line Operators to manipulate and analyse Climate and NWP model Data."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'pic': True}
+
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/20124']
+sources = [SOURCELOWER_TAR_GZ]
+
+# OpenMP support for compute intensive operators: https://code.zmaw.de/projects/cdo/wiki/OpenMP_support, no MPI support
+builddependencies = [
+    ('HDF5', '1.10.5'),
+    ('netCDF-Fortran', '4.4.5'),
+    ('UDUNITS', '2.2.26', '', True),
+    ('PROJ', '6.1.1'),
+    ('ecCodes', '2.13.0', '-python3'),
+    ('YAXT', '0.6.2'),
+]
+
+preconfigopts = " export NC_CONFIG=$EBROOTNETCDF/bin/nc-config && "
+configopts = " --with-szlib=$EBROOTSZIP --with-hdf5=$HDF5_DIR --with-netcdf=$EBROOTNETCDFMINFORTRAN  --with-udunits2=$EBROOTUDUNITS --with-fftw3 --with-proj=$EBROOTPROJ  --with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES "
+
+# fix for linking issues with HDF5 libraries for libcdi, should link with both -lnetcdf and -lhdf5_hl -lhdf5
+prebuildopts = "find libcdi -name Makefile -exec sed -i 's/-lnetcdf/-lnetcdff -lnetcdf/g' '{}' \; && "
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/c/cURL/cURL-7.65.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/c/cURL/cURL-7.65.1-fosscuda-2019b.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella(CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'cURL'
+version = '7.65.1'
+
+homepage = 'http://curl.haxx.se'
+description = """libcurl is a free and easy-to-use client-side URL transfer library,
+ supporting DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
+ POP3, POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP. libcurl supports
+ SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form based upload,
+ proxies, cookies, user+password authentication (Basic, Digest, NTLM, Negotiate,
+ Kerberos), file transfer resume, http proxy tunneling and more."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://%(namelower)s.haxx.se/download/']
+sources = [SOURCELOWER_TAR_GZ]
+
+modextravars = {'CURL_INCLUDES': '%(installdir)s/include'}
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib/libcurl.a', 'lib/libcurl.so'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.13.0-fosscuda-2019b-python3.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.13.0-fosscuda-2019b-python3.eb
@@ -1,0 +1,33 @@
+# contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.13.0'
+versionsuffix = '-python3'
+
+homepage = 'https://confluence.ecmwf.int/display/ECC/ecCodes+Home'
+description = """ecCodes is a package developed by ECMWF which provides an application programming interface 
+and a set of tools for decoding and encoding messages in the WMO GRIB and BUFR formats."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
+sources = ['%(namelower)s-%(version)s-Source.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('JasPer', '2.0.14'),
+    ('netCDF', '4.7.0'),
+    ('PyExtensions', '3.7.4'),
+]
+
+configopts = "-DENABLE_JPG=ON -DENABLE_NETCDF=ON -DENABLE_PYTHON=ON"
+
+separate_build_dir = True
+
+sanity_check_paths = {
+    'files': ['bin/bufr_copy', 'bin/bufr_dump', 'bin/bufr_filter', 'bin/bufr_ls', 'bin/codes_count', 'bin/codes_info', 'bin/codes_split_file', 'bin/grib_copy', 'bin/grib_dump', 'bin/grib_filter', 'bin/grib_ls'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompic-2019b.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompic-2019b.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.8'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete
+Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and
+of both real and complex data."""
+
+toolchain = {'name': 'gompic', 'version': '2019b'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = [
+    "--enable-threads --enable-openmp --with-pic --enable-single --enable-sse2 --enable-mpi",
+    "--enable-threads --enable-openmp --with-pic --enable-long-double --enable-mpi",
+    "--enable-threads --enable-openmp --with-pic --enable-quad-precision",
+    "--enable-threads --enable-openmp --with-pic --enable-sse2 --enable-mpi",
+]
+
+runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-wisdom', 'bin/%(namelower)s-wisdom-to-conf', 'bin/fftwf-wisdom', 'bin/fftwl-wisdom', 'bin/fftwq-wisdom', 'include/fftw3-mpi.f03', 'include/fftw3-mpi.h', 'include/fftw3.f', 'include/fftw3.f03', 'include/fftw3.h', 'include/fftw3l-mpi.f03', 'include/fftw3l.f03', 'include/fftw3q.f03', 'lib/libfftw3.a', 'lib/libfftw3_mpi.a', 'lib/libfftw3_omp.a', 'lib/libfftw3_threads.a', 'lib/libfftw3f.a', 'lib/libfftw3f_mpi.a', 'lib/libfftw3f_omp.a', 'lib/libfftw3f_threads.a', 'lib/libfftw3l.a', 'lib/libfftw3l_mpi.a', 'lib/libfftw3l_omp.a', 'lib/libfftw3l_threads.a', 'lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/fosscuda/fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/f/fosscuda/fosscuda-2019b.eb
@@ -1,0 +1,33 @@
+# Modified by MKr (CSCS) - based on easybuilders 'develop'
+easyblock = 'Toolchain'
+
+name = 'fosscuda'
+version = '2019b'
+
+homepage = '(none)'
+description = """
+    GCC based compiler toolchain __with CUDA support__, and including OpenMPI
+    for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK.
+"""
+
+toolchain = SYSTEM
+
+local_gccver = '8.3.0'
+
+# toolchain used to build fosscuda dependencies
+local_comp_mpi_tc = ('gompic', version)
+
+# compiler toolchain dependencies
+# We need GCC, CUDA and OpenMPI as explicit dependencies instead of
+# gompic toolchain because of toolchain preperation functions.
+dependencies = [
+    ('GCC', local_gccver),  # part of gompic
+    ('OpenMPI', '4.0.2', '-cuda-10.1', ('gcccuda', version)),  # part of gompic
+    ('CUDA', '10.1.243', '', True),
+    ('OpenBLAS', '0.3.7', '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.8', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '', local_comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'
+

--- a/easybuild/easyconfigs/g/GDAL/GDAL-3.0.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-3.0.1-fosscuda-2019b.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GDAL'
+version = '3.0.1'
+
+homepage = 'http://www.gdal.org/'
+description = """GDAL is a translator library for raster geospatial data formats that is released under an X/MIT style
+ Open Source license by the Open Source Geospatial Foundation. As a library, it presents a single abstract data model
+ to the calling application for all supported formats. It also comes with a variety of useful commandline utilities for
+ data translation and processing."""
+  
+toolchain = {'name': 'fosscuda', 'version': '2019b' }
+
+source_urls = ['http://download.osgeo.org/gdal/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('GEOS', '3.7.2'),
+    ('PROJ', '6.1.1'),
+    ('zlib', '1.2.11')
+]
+
+configopts = ' --with-geos=yes '
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.%s' % SHLIB_EXT, 'lib/libgdal.a'],
+    'dirs': ['bin', 'include']
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.7.2-fosscuda-2019b.eb
@@ -1,0 +1,20 @@
+# contributed by Luca Marsella (CSCS0
+easyblock = 'ConfigureMake'
+
+name = 'GEOS'
+version = "3.7.2"
+
+homepage = 'http://trac.osgeo.org/geos'
+description = """GEOS (Geometry Engine - Open Source) is a C++ port of the  Java Topology Suite (JTS)"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b' }
+
+source_urls = ['http://download.osgeo.org/geos/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+sanity_check_paths = {
+    'files': ['bin/geos-config', 'lib/libgeos.so', 'lib/libgeos.a', 'include/geos.h'],
+    'dirs': []
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GSL/GSL-2.5-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-2.5-fosscuda-2019b.eb
@@ -1,0 +1,25 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GSL'
+version = "2.5"
+
+homepage = 'http://www.gnu.org/software/gsl/'
+description = """The GNU Scientific Library (GSL) is a numerical library for C and C++ programmers.
+ The library provides a wide range of mathematical routines such as random number generators, special functions
+ and least-squares fitting."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'optarch': True, 'unroll': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = "--with-pic"
+
+sanity_check_paths={
+    'files': ['lib/libgsl.so', 'lib/libgsl.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/g/GSL/GSL-2.6-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-2.6-fosscuda-2019b.eb
@@ -1,0 +1,25 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GSL'
+version = "2.6"
+
+homepage = 'http://www.gnu.org/software/gsl/'
+description = """The GNU Scientific Library (GSL) is a numerical library for C and C++ programmers.
+ The library provides a wide range of mathematical routines such as random number generators, special functions
+ and least-squares fitting."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'optarch': True, 'unroll': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = "--with-pic"
+
+sanity_check_paths={
+    'files': ['lib/libgsl.so', 'lib/libgsl.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/g/gcccuda/gcccuda-2019b.eb
+++ b/easybuild/easyconfigs/g/gcccuda/gcccuda-2019b.eb
@@ -1,0 +1,21 @@
+# modified by MKr (CSCS) - based on easybuilders 'develop'
+easyblock = "Toolchain"
+
+name = 'gcccuda'
+version = '2019b'
+
+homepage = '(none)'
+description = """
+    GNU Compiler Collection (GCC) based compiler toolchain,
+    along with CUDA toolkit.
+"""
+
+toolchain = SYSTEM
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', '8.3.0'),
+    ('CUDA', '10.1.243', '', True),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompic/gompic-2019b.eb
+++ b/easybuild/easyconfigs/g/gompic/gompic-2019b.eb
@@ -1,0 +1,24 @@
+# Modified by Mkr (CSCS) - based on easybuilders 'develop'
+easyblock = "Toolchain"
+
+name = 'gompic'
+version = '2019b'
+
+homepage = '(none)'
+description = """
+    GNU Compiler Collection (GCC) based compiler toolchain along with CUDA
+    toolkit, including OpenMPI for MPI support with CUDA features enabled.
+"""
+
+toolchain = SYSTEM
+
+local_gccver = '8.3.0'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', local_gccver),  # part of gcccuda
+    ('OpenMPI', '4.0.2', '-cuda-10.1', ('gcccuda', version)),
+    ('CUDA', '10.1.243', '', True),  
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/h/HDF5/HDF5-1.10.5-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/h/HDF5/HDF5-1.10.5-fosscuda-2019b.eb
@@ -1,0 +1,23 @@
+# contributed by Luca Marsella (CSCS)
+name = 'HDF5'
+version = '1.10.5'
+
+homepage = 'http://www.hdfgroup.org/HDF5/'
+description = """HDF5 is a unique technology suite that makes possible the management of 
+ extremely large and complex data collections."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
+
+source_urls = ['https://support.hdfgroup.org/ftp/%(name)s/releases/%(namelower)s-%(version_major_minor)s/%(namelower)s-%(version)s/src']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Szip', '2.1.1'),
+]
+
+buildopts = 'CXXFLAGS="$CXXFLAGS -DMPICH_IGNORE_CXX_SEEK"'
+
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/i/inputproto/inputproto-2.3.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/i/inputproto/inputproto-2.3.2-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'inputproto'
+version = '2.3.2'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = "X.org InputProto protocol headers."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+sources = [SOURCE_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/XI2.h', 'include/X11/extensions/XI.h', 'include/X11/extensions/XIproto.h', 'include/X11/extensions/XI2proto.h'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/j/JasPer/JasPer-2.0.14-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/j/JasPer/JasPer-2.0.14-fosscuda-2019b.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'JasPer'
+version = '2.0.14'
+
+homepage = 'http://www.ece.uvic.ca/~frodo/jasper/'
+description = """
+    gzip (GNU zip) is a popular data compression program as a replacement 
+    for compress
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.ece.uvic.ca/~frodo/%(namelower)s/software/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+
+configopts = '-DJAS_ENABLE_DOC=FALSE'
+
+separate_build_dir = 'True'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib64/libjasper.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/k/kbproto/kbproto-1.0.7-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'kbproto'
+version = '1.0.7'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = "X.org KBProto protocol headers."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+sources = [SOURCE_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/XKBgeom.h', 'include/X11/extensions/XKB.h', 'include/X11/extensions/XKBproto.h', 'include/X11/extensions/XKBsrv.h', 'include/X11/extensions/XKBstr.h'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libX11/libX11-1.6.7-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libX11/libX11-1.6.7-fosscuda-2019b.eb
@@ -1,0 +1,30 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libX11'
+version = '1.6.7'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = "X11 client-side library"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = [XORG_LIB_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('xextproto', '7.3.0'),
+    ('xcb-proto', '1.13', '', True),
+    ('inputproto', '2.3.2'),
+    ('xproto', '7.0.31'),
+    ('kbproto', '1.0.7'),
+    ('xtrans', '1.4.0'),
+    ('libxcb', '1.13'),
+]
+
+sanity_check_paths = {
+    'files': ['include/X11/cursorfont.h', 'include/X11/ImUtil.h', 'include/X11/Xcms.h', 'include/X11/XKBlib.h', 'include/X11/XlibConf.h', 'include/X11/Xlib.h', 'include/X11/Xlibint.h', 'include/X11/Xlib-xcb.h', 'include/X11/Xlocale.h', 'include/X11/Xregion.h', 'include/X11/Xresource.h', 'include/X11/Xutil.h'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXau/libXau-1.0.9-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libXau/libXau-1.0.9-fosscuda-2019b.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libXau'
+version = '1.0.9'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = """The libXau package contains a library implementing the X11 Authorization Protocol.
+This is useful for restricting client access to the display."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'optarch': True}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/lib/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('xproto', '7.0.31'),
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.3-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libXdmcp/libXdmcp-1.1.3-fosscuda-2019b.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libXdmcp'
+version = '1.1.3'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = """The libXdmcp package contains a library implementing the X Display Manager Control Protocol. This is
+useful for allowing clients to interact with the X Display Manager.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'optarch': True}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/lib/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('xproto', '7.0.31'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-2.0.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libjpeg-turbo/libjpeg-turbo-2.0.2-fosscuda-2019b.eb
@@ -1,0 +1,34 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'libjpeg-turbo'
+version = '2.0.2'
+
+homepage = 'http://sourceforge.net/projects/libjpeg-turbo/'
+description = """libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG
+compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+"""
+
+toolchain = {'name':'fosscuda', 'version':'2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.14.3', '', True)]
+
+dependencies = [
+    ('NASM', '2.14.02'),
+]
+
+configopts = '-G"Unix Makefiles"'
+runtest = "test"
+
+sanity_check_paths = {
+    'files': ['bin/cjpeg', 'bin/djpeg', 'bin/jpegtran', 'bin/rdjpgcom', 'bin/tjbench', 'bin/wrjpgcom',
+              'lib/libjpeg.a', 'lib/libjpeg.%s' % SHLIB_EXT, 'lib/libturbojpeg.a', 'lib/libturbojpeg.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libsodium/libsodium-1.0.18-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libsodium/libsodium-1.0.18-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libsodium'
+version = '1.0.18'
+
+homepage = 'http://doc.libsodium.org/'
+description = """
+Sodium is a modern, easy-to-use software library for encryption, decryption, signatures, password hashing and more."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['https://download.libsodium.org/libsodium/releases/']
+sources = [SOURCE_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['include/sodium.h', 'lib/libsodium.so', 'lib/libsodium.a'],
+    'dirs': ['include/sodium', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libxcb/libxcb-1.13-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libxcb/libxcb-1.13-fosscuda-2019b.eb
@@ -1,0 +1,34 @@
+# contributed byLuca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libxcb'
+version = '1.13'
+
+homepage = 'http://xcb.freedesktop.org/'
+description = """The X protocol C-language Binding (XCB) is a replacement for Xlib featuring a small footprint,
+latency hiding, direct access to the protocol, improved threading support, and extensibility."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://xcb.freedesktop.org/dist/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('xcb-proto', '1.13', '', True),
+    ('xproto', '7.0.31'),
+]
+dependencies = [
+    ('libXau', '1.0.9'),
+    ('libXdmcp', '1.1.3'),
+]
+
+preconfigopts = ' sed -i "s/pthread-stubs//" configure && '
+configopts = " $XORG_CONFIG --enable-xevie --enable-xprint --without-doxygen "
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s-composite.a', 'lib/%(name)s-damage.a', 'lib/%(name)s-dpms.a', 'lib/%(name)s-dri2.a', 'lib/%(name)s-glx.a', 'lib/%(name)s-randr.a', 'lib/%(name)s-record.a', 'lib/%(name)s-render.a', 'lib/%(name)s-res.a', 'lib/%(name)s-screensaver.a', 'lib/%(name)s-shape.a', 'lib/%(name)s-shm.a', 'lib/%(name)s-sync.a', 'lib/%(name)s-xevie.a', 'lib/%(name)s-xf86dri.a', 'lib/%(name)s-xfixes.a', 'lib/%(name)s-xinerama.a', 'lib/%(name)s-xprint.a', 'lib/%(name)s-xtest.a', 'lib/%(name)s-xv.a', 'lib/%(name)s-xvmc.a'],
+    'dirs': ['include/xcb', 'lib/pkgconfig'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NASM/NASM-2.14.02-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/NASM/NASM-2.14.02-fosscuda-2019b.eb
@@ -1,0 +1,20 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'NASM'
+version = '2.14.02'
+
+homepage = 'http://www.nasm.us/'
+description = """NASM: General-purpose x86 assembler"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://www.nasm.us/pub/nasm/releasebuilds/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+
+sanity_check_paths = {
+    'files': ['bin/nasm'],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/NCO/NCO-4.8.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/NCO/NCO-4.8.1-fosscuda-2019b.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'NCO'
+version = '4.8.1'
+
+homepage = 'http://nco.sourceforge.net/'
+description = """CDO is a collection of command line Operators to manipulate and analyse Climate and NWP model Data."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'pic': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://nco.sourceforge.net/src/']
+
+# OpenMP support by default, no MPI support
+dependencies = [
+    ('HDF5', '1.10.5'),
+    ('netCDF-Fortran', '4.4.5'),
+    ('cURL', '7.65.1'),
+    ('JasPer', '2.0.14'),
+    ('UDUNITS', '2.2.26', '', True),
+]
+
+configopts = "--disable-ncap2 "
+
+sanity_check_paths = {
+    'files': ["bin/ncbo"],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/ncview/ncview-2.1.7-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/ncview/ncview-2.1.7-fosscuda-2019b.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ncview'
+version = '2.1.7'
+
+homepage = 'http://meteora.ucsd.edu/~pierce/ncview_home_page.html'
+description = """Ncview is a visual browser for netCDF format files."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['ftp://cirrus.ucsd.edu/pub/ncview/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('netCDF', '4.7.0'),
+    ('HDF5', '1.10.5'),
+    ('UDUNITS', '2.2.26', '', True),
+    ('libpng', '1.6.37'), 
+    ('zlib', '1.2.11'),
+    ('cURL', '7.65.1'),
+]
+
+configopts = 'CC=`which mpicc`'
+
+sanity_check_paths = {
+    'files': ['bin/ncview'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/netCDF-C++/netCDF-C++-4.3.0-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/netCDF-C++/netCDF-C++-4.3.0-fosscuda-2019b.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'netCDF-C++'
+version = '4.3.0'
+
+homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
+description = """NetCDF (network Common Data Form) is a set of software libraries 
+ and machine-independent data formats that support the creation, access, and sharing of array-oriented 
+ scientific data."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/Unidata/netcdf-cxx4/archive/']
+sources = ['v%(version)s.tar.gz']
+
+dependencies = [
+    ('netCDF', '4.7.0'),
+]
+
+
+sanity_check_paths = {
+    'files': ['include/netcdf', 'include/ncDouble.h', 'bin/ncxx4-config', 'lib/pkgconfig/netcdf-cxx4.pc', 'lib/libnetcdf_c++4.a', 'lib/libnetcdf_c++4.so'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.4.5-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/netCDF-Fortran/netCDF-Fortran-4.4.5-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+name = 'netCDF-Fortran'
+version = '4.4.5'
+
+homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
+description = """NetCDF (network Common Data Form) is a set of software libraries 
+ and machine-independent data formats that support the creation, access, and sharing of array-oriented 
+ scientific data."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['ftp://ftp.unidata.ucar.edu/pub/netcdf/', 'ftp://ftp.unidata.ucar.edu/pub/netcdf/old']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('netCDF', '4.7.0'),
+]
+
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netCDF/netCDF-4.7.0-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/n/netCDF/netCDF-4.7.0-fosscuda-2019b.eb
@@ -1,0 +1,39 @@
+# contributed by Luca Marsella (CSCS)
+name = 'netCDF'
+version = '4.7.0'
+
+homepage = 'http://www.unidata.ucar.edu/software/netcdf/'
+description = """NetCDF (network Common Data Form) is a set of software libraries 
+ and machine-independent data formats that support the creation, access, and sharing of array-oriented 
+ scientific data."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/Unidata/%(namelower)s-c/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+dependencies = [
+    ('cURL', '7.65.1'),
+    ('HDF5', '1.10.5'),
+]
+
+# make sure both static and shared libs are built
+configopts = [
+    "-DCURL_LIBRARY=$EBROOTCURL/lib/libcurl.so -DCURL_INCLUDE_DIR=$EBROOTCURL/include -DBUILD_SHARED_LIBS=ON -DCMAKE_C_FLAGS='-DHAVE_STRDUP'",
+    "-DCURL_LIBRARY=$EBROOTCURL/lib/libcurl.so -DCURL_INCLUDE_DIR=$EBROOTCURL/include -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS='-DHAVE_STRDUP'",
+]
+
+maxparallel = 1
+
+postinstallcmds = ['ln -s %(installdir)s/lib64 %(installdir)s/lib']
+
+sanity_check_paths = {
+    'files': ['lib64/libnetcdf.so', 'lib64/libnetcdf.a'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.2-gcccuda-2019b-cuda-10.1.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.2-gcccuda-2019b-cuda-10.1.eb
@@ -1,0 +1,71 @@
+# Modified for Tsa/Arolla by MKr - July 2019
+name = 'OpenMPI'
+version = "4.0.2"
+local_cudaversion = '10.1'
+versionsuffix = '-cuda-%s' % local_cudaversion
+
+homepage = 'https://www.open-mpi.org/'
+description = """
+    The Open MPI Project is an open source MPI-3 implementation.
+"""
+
+toolchain = {'name': 'gcccuda', 'version': '2019b'}
+
+source_urls = [
+    'https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads'
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('UCX', '1.6.1', '-cuda-10.1', ('GCC', '8.3.0')),
+]
+
+configopts = (
+    "--enable-shared "
+    "--with-pmi=/opt/slurm/default "
+    "--enable-static "
+    "--enable-mpi-cxx "
+    "--with-zlib "
+    "--without-libfabric "
+    "--with-ucx=${EBROOTUCX} "
+    "--without-mxm "
+    "--without-verbs "
+    "--without-psm2 "
+    "--without-alps "
+    "--without-tm "
+    "--disable-memchecker "
+    "--with-hwloc=/usr/ "
+    "--enable-dlopen "
+    "--enable-cxx-exceptions "
+    "--with-cuda "
+    "--without-lsf "
+    "--without-sge "
+    "--enable-mpirun-prefix-by-default "
+    "--enable-mca-no-build=btl-uct "
+    "--enable-mpi1-compatibility "
+)
+
+parallel = 8
+
+postinstallcmds = [
+    "sed -i -e '50 i mtl=^ofi' %(installdir)s/etc/%(namelower)s-mca-params.conf",
+    "sed -i -e '50 i pml=ucx' %(installdir)s/etc/%(namelower)s-mca-params.conf",
+]
+
+modtclfooter = """
+    setenv UCX_TLS rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma
+"""
+
+local_libs = ["mpif_mpifh", "mpi", "ompitrace", "open-pal", "open-rte"]
+sanity_check_paths = {
+    'files': [
+        ["bin/%s" % local_binfile 
+        for local_binfile in ["ompi_info","opal_wrapper","orterun"]] +
+        ["lib/lib%s.%s" % (local_libfile, SHLIB_EXT) for local_libfile in local_libs] +
+        ["include/%s.h" % local_x 
+        for local_x in ["mpi-ext","mpif-config","mpif","mpi","mpi_portable_platform"]]
+    ],
+    'dirs': [],
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/p/PROJ/PROJ-6.1.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-6.1.1-fosscuda-2019b.eb
@@ -1,0 +1,23 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PROJ'
+version = '6.1.1'
+
+homepage = 'http://trac.osgeo.org/proj/'
+description = """Program proj is a standard Unix filter function which converts 
+geographic longitude and latitude coordinates into cartesian coordinates"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True}
+
+source_urls = ['http://download.osgeo.org/%(namelower)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['bin/cs2cs', 'bin/geod', 'bin/invgeod', 'bin/invproj', 'bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-tsa-18.1.eb
+++ b/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-tsa-18.1.eb
@@ -1,20 +1,22 @@
 # contributed by Luca Marsella (CSCS)
 easyblock = 'Bundle'
 
-prgenv = 'gnu' 
 name = 'PrgEnv-%s' % prgenv
 version = '18.1'
-fossversion = '2018b'
+local_prgenv = 'gnu' 
+local_fossversion = '2018b'
 
 homepage = 'http://user.cscs.ch'
 description = """
-    The meta-module sets the MODULEPATH to access the following programming environment: 
+    The meta-module sets the MODULEPATH to access the following programming
+    environment: 
         - %s %s
 """ % (name, version) 
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = SYSTEM
 
-path='/apps/arolla/UES/jenkins/RH7.6/%s/%s/easybuild/modules/all' % (prgenv, version)
+local_path='/apps/arolla/UES/jenkins/RH7.6/%s/%s/easybuild/modules/all' % 
+           (local_prgenv, version)
 
 modtclfooter = """
 set list [exec ls --color=none %s ]
@@ -35,6 +37,6 @@ if { [module-info mode load] } {
   module load openmpi/4.0.1-gcc-7.3.0-2.30-cuda-10.0
  }
 }
-""" % (path, path, path)
+""" % (local_path, local_path, local_path)
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-tsa-19.2.eb
+++ b/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-tsa-19.2.eb
@@ -1,20 +1,22 @@
 # contributed by Luca Marsella (CSCS)
 easyblock = 'Bundle'
 
-prgenv = 'gnu' 
 name = 'PrgEnv-%s' % prgenv
 version = '19.2'
-fossversion = '2019.02'
+local_prgenv = 'gnu' 
+local_fossversion = '2019b'
 
 homepage = 'http://user.cscs.ch'
 description = """
-    The meta-module sets the MODULEPATH to access the following programming environment: 
+    The meta-module sets the MODULEPATH to access the following programming
+    environment: 
         - %s %s
 """ % (name, version) 
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = SYSTEM
 
-path='/apps/arolla/UES/jenkins/RH7.6/%s/%s/easybuild/modules/all' % (prgenv, version)
+local_path = '/apps/arolla/UES/jenkins/RH7.6/%s/%s/easybuild/modules/all' % 
+             (local_prgenv, version)
 
 modtclfooter = """
 set list [exec ls --color=none %s ]
@@ -31,10 +33,10 @@ if { [module-info mode remove] || [module-info mode switch] } {
 
 if { [module-info mode load] } {
  module use %s
- if { ![ is-loaded foss/.%s ] } {
-  module load foss/.%s
+ if { ![ is-loaded fosscuda/.%s ] } {
+  module load fosscuda/.%s
  }
 }
-""" % (path, path, path, fossversion, fossversion)
+""" % (local_path, local_path, local_path, local_fossversion, local_fossversion)
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -1,0 +1,59 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+
+name = 'PyExtensions'
+local_py_maj_ver = '2'
+local_py_min_ver = '7'
+local_py_rev_ver = '16'
+local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
+version = '%s.%s' % (local_pyver, local_py_rev_ver)
+
+homepage = 'https://pypi.python.org/pypi'
+description = """This module is a bundle of Python packages based on a generic Python module"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+dependencies = [
+    ('Python', '%s' % version, '', True),
+]
+
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+exts_list = [
+    ('numpy', '1.16.4', {
+        'source_urls': ['http://pypi.python.org/packages/source/n/numpy/'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+    }),
+# matplotlib >= 3 requires python >= 3.5
+    ('matplotlib', '2.2.4', {
+        'source_urls': ['http://pypi.python.org/packages/source/m/matplotlib/'],
+    }),
+    ('mpi4py', '3.0.2', {
+        'source_urls': ['http://pypi.python.org/packages/source/m/mpi4py/'],
+    }),
+    ('pandas', '0.24.2', {
+        'source_urls': ['http://pypi.python.org/packages/source/p/pandas/'],
+    }),
+# scipy >= 1.3.0 requires python >= 3.5
+    ('scipy', '1.2.2', {
+        'source_urls': ['http://pypi.python.org/packages/source/s/scipy/'],
+    }),
+    ('sympy', '1.4', {
+        'source_urls': ['http://pypi.python.org/packages/source/s/sympy/'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+local_full_sanity_check = True
+
+local_pythonpath = 'lib/python%s/site-packages' % local_pyver
+sanity_check_paths = {
+    'files': [],
+    'dirs': [local_pythonpath]
+}
+
+modextrapaths = {'PYTHONPATH': local_pythonpath}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.7.4-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.7.4-fosscuda-2019b.eb
@@ -1,0 +1,35 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+
+name = 'PyExtensions'
+version = '3.7.4'
+
+homepage = 'https://pypi.python.org/pypi'
+description = "This module is a bundle of Python packages based on a generic Python module"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+dependencies = [
+    ('Python', '3.7.4', '', True),
+]
+
+# extensions list updated July 15th 2019
+exts_list = [
+    ('numpy', '1.16.4', {'source_tmpl': '%(name)s-%(version)s.zip', 'source_urls': ['http://pypi.python.org/packages/source/n/numpy/']}),
+    ('matplotlib', '3.1.1', {'source_urls': ['http://pypi.python.org/packages/source/m/matplotlib/']}),
+    ('mpi4py', '3.0.2', {'source_urls': ['http://pypi.python.org/packages/source/m/mpi4py/']}),
+    ('pandas', '0.24.2', {'source_urls': ['http://pypi.python.org/packages/source/p/pandas/']}),
+    ('scipy', '1.3.0', {'source_urls': ['http://pypi.python.org/packages/source/s/scipy/']}),
+    ('sympy', '1.4', {'source_urls': ['http://pypi.python.org/packages/source/s/sympy/']}),
+]
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/r/R/R-3.5.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.5.2-fosscuda-2019b.eb
@@ -1,0 +1,71 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+name = 'R'
+version = '3.5.2'
+
+homepage = 'http://www.r-project.org/'
+
+description = """
+R is a free software environment for statistical computing and graphics.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://stat.ethz.ch/CRAN/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
+
+# foss loads OpenBLAS and uses LAPACK
+preconfigopts = 'BLAS_LIBS="$LIBBLAS"' 
+configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix)
+configopts += " --with-recommended-packages=no "
+
+builddependencies = [ 
+    ('bzip2', '1.0.6', '', True),
+    ('XZ', '5.2.4', '', True),
+    ('PCRE', '8.43', '', True),
+    ('libreadline', '8.0', '', True),
+    ('ncurses', '6.1', '', True),
+    ('cURL', '7.65.1'),
+    ('libX11', '1.6.7'),
+    ('libpng', '1.6.37'),               # for plotting in R
+    ('libjpeg-turbo', '2.0.2'),         # for plottting in R
+    ('libsodium', '1.0.18'),            # for sodium
+    ('Java', '1.8.0_212', '', True),    # Java bindings
+    ('GDAL', '3.0.1'),                  
+    ('PROJ', '6.1.1'),                  # for rgdal
+    ('GEOS', '3.7.2'),                  # for rgeos
+]
+
+local_name_tmpl = '%(name)s_%(version)s.tar.gz'
+local_ext_options = {
+    'source_urls': [
+        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'http://cran.r-project.org/src/contrib/',  # current version of packages
+        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': local_name_tmpl,
+}
+
+exts_list = [
+    # default libraries, only here to sanity check their presence
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    # non-standard libraries, should be specified with fixed versions!
+    ('lattice', '0.20-38', local_ext_options),
+    ('sp', '1.3-1', local_ext_options),
+    ('rgdal', '1.4-4', local_ext_options),
+    ('rgeos', '0.4-3' , local_ext_options),
+    ('rJava', '0.9-11', local_ext_options),
+    ('sodium', '1.1', local_ext_options)
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/R/R-3.6.1-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.1-fosscuda-2019b.eb
@@ -1,0 +1,71 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+name = 'R'
+version = '3.6.1'
+
+homepage = 'http://www.r-project.org/'
+
+description = """
+R is a free software environment for statistical computing and graphics.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://stat.ethz.ch/CRAN/src/base/R-%(version_major)s']
+sources = [SOURCE_TAR_GZ]
+
+# foss loads OpenBLAS and uses LAPACK
+preconfigopts = 'BLAS_LIBS="$LIBBLAS"' 
+configopts = "--with-lapack --with-blas --with-pic --enable-threads --with-x=yes --enable-R-shlib"
+# some recommended packages may fail in a parallel build (e.g. Matrix)
+configopts += " --with-recommended-packages=no "
+
+builddependencies = [ 
+    ('bzip2', '1.0.6', '', True),
+    ('XZ', '5.2.4', '', True),
+    ('PCRE', '8.43', '', True),
+    ('libreadline', '8.0', '', True),
+    ('ncurses', '6.1', '', True),
+    ('cURL', '7.65.1'),
+    ('libX11', '1.6.7'),
+    ('libpng', '1.6.37'),               # for plotting in R
+    ('libjpeg-turbo', '2.0.2'),         # for plottting in R
+    ('libsodium', '1.0.18'),            # for sodium
+    ('Java', '1.8.0_212', '', True),    # Java bindings
+    ('GDAL', '3.0.1'),                  
+    ('PROJ', '6.1.1'),                  # for rgdal
+    ('GEOS', '3.7.2'),                  # for rgeos
+]
+
+local_name_tmpl = '%(name)s_%(version)s.tar.gz'
+local_ext_options = {
+    'source_urls': [
+        'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'http://cran.r-project.org/src/contrib/',  # current version of packages
+        'http://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': local_name_tmpl,
+}
+
+exts_list = [
+    # default libraries, only here to sanity check their presence
+    'base',
+    'datasets',
+    'graphics',
+    'grDevices',
+    'grid',
+    'methods',
+    'splines',
+    'stats',
+    'stats4',
+    'tools',
+    'utils',
+    # non-standard libraries, should be specified with fixed versions!
+    ('lattice', '0.20-38', local_ext_options),
+    ('sp', '1.3-1', local_ext_options),
+    ('rgdal', '1.4-4', local_ext_options),
+    ('rgeos', '0.4-3' , local_ext_options),
+    ('rJava', '0.9-11', local_ext_options),
+    ('sodium', '1.1', local_ext_options)
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/Ruby/Ruby-2.4.0-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/Ruby/Ruby-2.4.0-fosscuda-2019b.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Ruby'
+version = '2.4.0'
+
+homepage = 'https://www.ruby-lang.org'
+description = """Ruby is a dynamic, open source programming language with 
+ a focus on simplicity and productivity. It has an elegant syntax that is 
+ natural to read and easy to write."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://cache.ruby-lang.org/pub/ruby/']
+
+sanity_check_paths = {
+    'files': ['bin/ruby', 'bin/rake', 'bin/gem', 'bin/erb',
+              'bin/ri', 'bin/irb', 'bin/rdoc', 'lib/libruby.so.2.4.0',
+              'lib/libruby.so'],
+    'dirs': ['lib/ruby/2.4.0', 'lib/ruby/gems', 'include/ruby-2.4.0']
+}
+
+configopts = "--disable-install-doc --enable-shared"
+builddependencies = [
+    ('GSL', '2.5')
+]
+
+postinstallcmds = [" %(installdir)s/bin/gem install --no-document bigdecimal io-console json  mail mime-types minitest more_rinda narray net-ssh open4 pony power_assert psych rb-gsl rinruby ruby-prof test-unit xml-simple svn2git"]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/Ruby/Ruby-2.6.5-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/r/Ruby/Ruby-2.6.5-fosscuda-2019b.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Ruby'
+local_maj_ver = '2.6'
+version = '%s.5' % local_maj_ver
+
+homepage = 'https://www.ruby-lang.org'
+description = """Ruby is a dynamic, open source programming language with 
+ a focus on simplicity and productivity. It has an elegant syntax that is 
+ natural to read and easy to write."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://cache.ruby-lang.org/pub/ruby/%s' % local_maj_ver]
+
+sanity_check_paths = {
+    'files': ['bin/ruby', 'bin/rake', 'bin/gem', 'bin/erb', 'bin/ri', 'bin/irb', 'bin/rdoc', 
+              'lib/libruby.so.%s' % version, 'lib/libruby.so.%s' % local_maj_ver, 'lib/libruby.so'],
+    'dirs': ['lib/ruby/%s.0' % local_maj_ver, 'lib/ruby/gems', 'include/ruby-%s.0' % local_maj_ver]
+}
+
+configopts = "--disable-install-doc --enable-shared"
+builddependencies = [
+    ('GSL', '2.6')
+]
+
+postinstallcmds = [" %(installdir)s/bin/gem install --no-document bigdecimal io-console json  mail mime-types minitest more_rinda narray net-ssh open4 pony power_assert psych rb-gsl rinruby ruby-prof test-unit xml-simple svn2git"]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2019b.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2019b.eb
@@ -1,0 +1,18 @@
+#
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompic', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
+
+dependencies = [('OpenBLAS', '0.3.7')]
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/x/xextproto/xextproto-7.3.0-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/x/xextproto/xextproto-7.3.0-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'xextproto'
+version = '7.3.0'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = "XExtProto protocol headers."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+sources = [SOURCE_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['include/X11/extensions/agproto.h', 'include/X11/extensions/cupproto.h', 'include/X11/extensions/dbeproto.h', 'include/X11/extensions/dpmsproto.h', 'include/X11/extensions/EVIproto.h', 'include/X11/extensions/geproto.h', 'include/X11/extensions/lbxproto.h', 'include/X11/extensions/mitmiscproto.h', 'include/X11/extensions/multibufproto.h', 'include/X11/extensions/securproto.h', 'include/X11/extensions/shapeproto.h', 'include/X11/extensions/shm.h', 'include/X11/extensions/shmstr.h', 'include/X11/extensions/syncproto.h', 'include/X11/extensions/xtestconst.h', 'include/X11/extensions/xtestext1proto.h'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xorg-macros/xorg-macros-1.19.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/x/xorg-macros/xorg-macros-1.19.2-fosscuda-2019b.eb
@@ -1,0 +1,28 @@
+# contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'xorg-macros'
+version = '1.19.2'
+
+homepage = 'http://cgit.freedesktop.org/xorg/util/macros'
+description = "X.org macros utilities."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://cgit.freedesktop.org/xorg/util/macros/snapshot']  # no slash ('/') at the end!
+sources = ['util-macros-%(version)s.tar.gz']
+
+builddependencies = [
+    ('binutils', '2.32', '', ('GCCcore', '8.3.0')),
+    ('Autotools', '20180311', '', True),
+]
+
+preconfigopts = "./autogen.sh && "
+
+
+sanity_check_paths = {
+    'files': ['share/pkgconfig/%(name)s.pc'],
+    'dirs': [],
+}  # use same binutils version that was used when building GCC toolchain
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xproto/xproto-7.0.31-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/x/xproto/xproto-7.0.31-fosscuda-2019b.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'xproto'
+version = '7.0.31'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = "X protocol and ancillary headers"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['http://xorg.freedesktop.org/archive/individual/proto/']
+sources = [SOURCE_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['include/X11/ap_keysym.h', 'include/X11/HPkeysym.h', 'include/X11/keysym.h', 'include/X11/Xalloca.h', 'include/X11/Xatom.h', 'include/X11/XF86keysym.h', 'include/X11/Xfuncs.h', 'include/X11/Xmd.h', 'include/X11/Xos.h', 'include/X11/Xpoll.h', 'include/X11/Xprotostr.h', 'include/X11/Xw32defs.h', 'include/X11/Xwindows.h', 'include/X11/DECkeysym.h', 'include/X11/keysymdef.h', 'include/X11/Sunkeysym.h', 'include/X11/Xarch.h', 'include/X11/Xdefs.h', 'include/X11/Xfuncproto.h', 'include/X11/X.h', 'include/X11/Xosdefs.h', 'include/X11/Xos_r.h', 'include/X11/Xproto.h', 'include/X11/Xthreads.h', 'include/X11/XWDFile.h', 'include/X11/Xwinsock.h'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/x/xtrans/xtrans-1.4.0-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/x/xtrans/xtrans-1.4.0-fosscuda-2019b.eb
@@ -1,0 +1,30 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'xtrans'
+version = '1.4.0'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/xlibs'
+description = """xtrans includes a number of routines to make X implementations transport-independent;
+ at time of writing, it includes support for UNIX sockets, IPv4, IPv6, and DECnet.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['https://github.com/freedesktop/xorg-libxtrans/archive/']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('gettext', '0.20.1', '', ('GCCcore', '8.3.0')),
+    ('xorg-macros', '1.19.2'),
+]
+
+preconfigopts = " ./autogen.sh && "
+
+
+sanity_check_paths = {
+    'files': ['include/X11/Xtrans/transport.c', 'include/X11/Xtrans/Xtrans.c', 'include/X11/Xtrans/Xtrans.h', 'include/X11/Xtrans/Xtransint.h', 'include/X11/Xtrans/Xtranslcl.c', 'include/X11/Xtrans/Xtranssock.c', 'include/X11/Xtrans/Xtransutil.c'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/y/YAXT/YAXT-0.6.2-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/y/YAXT/YAXT-0.6.2-fosscuda-2019b.eb
@@ -1,0 +1,24 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'YAXT'
+version = '0.6.2'
+
+homepage = 'https://www.dkrz.de/redmine/projects/yaxt'
+description = "Yet Another eXchange Tool"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.dkrz.de/redmine/attachments/download/492']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = 'FC="$F90" FCFLAGS="$F90FLAGS -cpp"'
+
+
+sanity_check_paths = {
+    'files': ['include/%(namelower)s.h', 'include/%(namelower)s.mod', 'lib/libyaxt.a', 'lib/libyaxt.so'],
+    'dirs': ['include/xt'],
+}
+
+moduleclass = 'tools'

--- a/jenkins-builds/MCH-RH7.6-19.04
+++ b/jenkins-builds/MCH-RH7.6-19.04
@@ -2,7 +2,7 @@
  Autotools-20180311.eb                               
  binutils-2.30-GCCcore-7.3.0.eb                     --hidden
  CMake-3.14.5.eb                                    
- CUDA-10.1.243.eb                                   --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ CUDA-10.1.243.eb
  ddt-19.0.5-Redhat-7.0.eb                           --set-default-module
  git-2.22.0.eb                                      
  IDL-8.5.1-MCH.eb
@@ -14,33 +14,51 @@
  Python-3.7.4.eb                                    
  rstudio-1.2.1335.eb                                --disable-rpath
  UCX-1.5.2-GCCcore-7.3.0-cuda-10.0.eb               --hidden
+ UCX-1.6.1-GCC-8.3.0-cuda-10.1.eb                   --hidden
  vampir-9.6.0.eb                                    
  Vim-8.1.eb 					    
  nmon-16g.eb                                        
  reframe-2.18.eb
- netCDF-C++-4.3.0-CrayCCE-19.04.eb                  --installpath=/apps/arolla/UES/jenkins/RH7.6/cce/19.04/easybuild --module-naming-scheme=EasyBuildMNS --optarch=x86-skylake --disable-rpath
- netCDF-Fortran-4.4.4-CrayCCE-19.04.eb              --installpath=/apps/arolla/UES/jenkins/RH7.6/cce/19.04/easybuild --module-naming-scheme=EasyBuildMNS --optarch=x86-skylake --disable-rpath
  Boost-1.70.0-foss-2018b-python2.eb                 --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ Boost-1.70.0-fosscuda-2019b-python2.eb             --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
  Boost-1.70.0-foss-2018b-python3.eb                 --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- CDO-1.9.7.1-foss-2018b.eb 			    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- NCO-4.8.1-foss-2018b.eb			    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- ncview-2.1.7-foss-2018b.eb 			    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ Boost-1.70.0-fosscuda-2019b-python3.eb             --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ CDO-1.9.7.1-foss-2018b.eb 			                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ CDO-1.9.7.1-fosscuda-2019b.eb                      --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ NCO-4.8.1-foss-2018b.eb			                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ NCO-4.8.1-fosscuda-2019b.eb                        --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ ncview-2.1.7-foss-2018b.eb 			            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ ncview-2.1.7-fosscuda-2019b.eb                     --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ PyExtensions-2.7.16-foss-2018b.eb 		            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ PyExtensions-2.7.16-fosscuda-2019b.eb              --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ PyExtensions-3.7.4-foss-2018b.eb 		            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ PyExtensions-3.7.4-fosscuda-2019b.eb               --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ R-3.5.2-foss-2018b.eb 				                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild --set-default-module
+ R-3.5.2-fosscuda-2019b.eb 				            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild --set-default-module
+ R-3.6.1-foss-2018b.eb 				                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ R-3.6.1-fosscuda-2019b.eb 				            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ Ruby-2.4.0-foss-2018b.eb 			                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild --set-default-module
+ Ruby-2.4.0-fosscuda-2019b.eb 			            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild --set-default-module
+ Ruby-2.6.3-foss-2018b.eb 			                --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ Ruby-2.6.3-fosscuda-2019b.eb 			            --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ netCDF-C++-4.3.0-CrayCCE-19.04.eb                  --installpath=/apps/arolla/UES/jenkins/RH7.6/cce/19.04/easybuild --module-naming-scheme=EasyBuildMNS --optarch=x86-skylake --disable-rpath
  netCDF-C++-4.3.0-foss-2018b.eb                     --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- netCDF-Fortran-4.4.5-foss-2018b.eb                 --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- PyExtensions-2.7.16-foss-2018b.eb 		    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- PyExtensions-3.7.4-foss-2018b.eb 		    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- R-3.5.2-foss-2018b.eb 				    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild --set-default-module
- R-3.6.1-foss-2018b.eb 				    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- Ruby-2.4.0-foss-2018b.eb 			    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild --set-default-module
- Ruby-2.6.3-foss-2018b.eb 			    --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
- netCDF-C++-4.3.0-foss-2019.02.eb                   --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
- netCDF-Fortran-4.4.5-foss-2019.02.eb               --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
+ netCDF-C++-4.3.0-fosscuda-2019b.eb                 --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
  netCDF-C++-4.3.0-PGI-19.5-GCC-7.3.0-2.30.eb        --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.5/easybuild
+ netCDF-C++-4.3.0-PGI-19.9-GCC-8.3.0.eb             --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild
+ netCDF-Fortran-4.4.4-CrayCCE-19.04.eb              --installpath=/apps/arolla/UES/jenkins/RH7.6/cce/19.04/easybuild --module-naming-scheme=EasyBuildMNS --optarch=x86-skylake --disable-rpath
+ netCDF-Fortran-4.4.5-foss-2018b.eb                 --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ netCDF-Fortran-4.4.5-fosscuda-2019b.eb             --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
  netCDF-Fortran-4.4.5-PGI-19.5-GCC-7.3.0-2.30.eb    --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.5/easybuild
+ netCDF-Fortran-4.4.5-PGI-19.9-GCC-8.3.0.eb         --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild
+ OpenMPI-4.0.1-GCC-7.3.0-2.30-cuda-10.0.eb          --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/18.1/easybuild
+ OpenMPI-4.0.2-gcccuda-2019b-cuda-10.1.eb           --installpath=/apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild
  OpenMPI-4.0.1-PGI-19.5-GCC-7.3.0-2.30-cuda-10.0.eb --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.5/easybuild
  OpenMPI-4.0.1-PGI-19.7-GCC-7.3.0-2.30-cuda-10.0.eb --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.7/easybuild
- PrgEnv-cce-tsa-19.04.eb                            --module-naming-scheme=EasyBuildMNS
- PrgEnv-gnu-tsa-18.1.eb                             --module-naming-scheme=EasyBuildMNS
+ OpenMPI-4.0.2-PGI-19.9-GCC-8.3.0-cuda-10.1.eb      --installpath=/apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild
+ PrgEnv-cce-tsa-19.04.eb                            --module-naming-scheme=EasyBuildMNS --set-default-module
+ PrgEnv-gnu-tsa-18.1.eb                             --module-naming-scheme=EasyBuildMNS --set-default-module
  PrgEnv-gnu-tsa-19.2.eb                             --module-naming-scheme=EasyBuildMNS
- PrgEnv-pgi-tsa-19.5.eb                             --module-naming-scheme=EasyBuildMNS
+ PrgEnv-pgi-tsa-19.5.eb                             --module-naming-scheme=EasyBuildMNS --set-default-module
  PrgEnv-pgi-tsa-19.7.eb                             --module-naming-scheme=EasyBuildMNS
+ PrgEnv-pgi-tsa-19.9.eb                             --module-naming-scheme=EasyBuildMNS


### PR DESCRIPTION
This PR should add the complete toolchain "fosscuda-2019b", which is based on GCC 8.3.0 and contains OpenMPI/4.0.2.

The production list file is based on the PGI 19.9 toolchain, therefore, it is probably best to first merge #10 . 

**Note:** PrgEnv-gnu/18.1 and PrgEnv-pgi/19.5 are set as default modules!